### PR TITLE
Adjust docker image path with giantswarm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ export PATH := $(PWD)/bin:$(PATH)
 
 VERSION ?= $(shell ./scripts/git-version)
 
-DOCKER_REPO=quay.io/dexidp/dex
-DOCKER_IMAGE=$(DOCKER_REPO):$(VERSION)
+DOCKER_REPO=quay.io/giantswarm/dex
+DOCKER_IMAGE=$(DOCKER_REPO):$(VERSION)-giantswarm
 
 $( shell mkdir -p bin )
 


### PR DESCRIPTION
I've created `v2.x.x-giantswarm` branch from latest upstream tag to keep our changes in it and release from it.
When we need to sync changes from upstream, 

1. sync upstream tag  to `v2.x.x-giantswarm` 
2. tag `v2.x.x-giantswarm` with upstream tag
3. build with `make docker-image` and push image to quay