### PR TITLE
Add more details to log messages and error

### DIFF
--- a/server/refreshhandlers.go
+++ b/server/refreshhandlers.go
@@ -62,11 +62,11 @@ func (s *Server) extractRefreshTokenFromRequest(r *http.Request) (*internal.Refr
 
 // getRefreshTokenFromStorage checks that refresh token is valid and exists in the storage and gets its info
 func (s *Server) getRefreshTokenFromStorage(clientID string, token *internal.RefreshToken) (*storage.RefreshToken, *refreshError) {
-	invalidErr := newBadRequestError("Refresh token is invalid or has already been claimed by another client.")
+	invalidErr := newBadRequestError(fmt.Sprintf("clientID %s refresh token (ID %s) is invalid or has already been claimed by another client.", clientID, token.RefreshId))
 
 	refresh, err := s.storage.GetRefresh(token.RefreshId)
 	if err != nil {
-		s.logger.Errorf("failed to get refresh token: %v", err)
+		s.logger.Errorf("clientID %s failed to get refresh token ID %s: %v", clientID, token.RefreshId, err)
 		if err != storage.ErrNotFound {
 			return nil, newInternalServerError()
 		}

--- a/server/refreshhandlers_test.go
+++ b/server/refreshhandlers_test.go
@@ -135,7 +135,7 @@ func TestRefreshTokenExpirationScenarios(t *testing.T) {
 				rotateRefreshTokens: true,
 				now:                 func() time.Time { return t0.Add(time.Second * 25) },
 			},
-			error: `{"error":"invalid_request","error_description":"Refresh token is invalid or has already been claimed by another client."}`,
+			error: `{"error":"invalid_request","error_description":"clientID test refresh token (ID test) is invalid or has already been claimed by another client."}`,
 		},
 		{
 			name:        "Obsolete tokens are allowed but token is expired globally",


### PR DESCRIPTION
This is an attempt to get more details for the case where dex logs

    failed to get refresh token: not found