### PR TITLE
Fix OIDC connector dropping rootCAs client on discovery override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- OIDC connector: retain the `rootCAs`-aware HTTP client when `providerDiscoveryOverrides` is set. Previously the overridden provider was rebuilt with a background context, so RFC 8693 token exchange verified the JWKS against the system trust store and failed with `x509: certificate signed by unknown authority` for issuers served behind a custom CA.
+
 ## [2.43.1-gs3] - 2026-02-20
 
 ### Fixed

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -164,7 +164,11 @@ func getProvider(ctx context.Context, issuer string, overrides ProviderDiscovery
 	if overrides.JWKSURL != "" {
 		config.JWKSURL = overrides.JWKSURL
 	}
-	return config.NewProvider(context.Background()), nil
+	// Build the overridden provider with the incoming ctx so it retains the
+	// rootCAs-aware oauth2.HTTPClient. Using context.Background() here drops
+	// that client, making the provider verify JWKS against system roots only,
+	// which breaks RFC 8693 token exchange against tunnelled (custom-CA) JWKS.
+	return config.NewProvider(ctx), nil
 }
 
 // NewGroupFromClaims creates a new group from a list of claims and appends it to the list of existing groups.

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -653,6 +654,60 @@ func TestTokenIdentity(t *testing.T) {
 	}
 }
 
+// TestTokenIdentityRootCAsWithOverride is a regression test for the override
+// branch of getProvider dropping the rootCAs-aware HTTP client.
+//
+// The connector is configured with both a custom RootCAs trust bundle (the
+// self-signed CA of a TLS test server) and ProviderDiscoveryOverrides, which
+// routes provider construction through getProvider's override branch. An
+// RFC 8693 id_token exchange then verifies the token signature, which requires
+// fetching the JWKS from the TLS server. That fetch uses the provider's
+// build-time HTTP client, so it only succeeds if the override branch retained
+// the rootCAs client.
+//
+// Before the fix the override branch built the provider with
+// context.Background(), discarding the rootCAs client; JWKS verification then
+// fell back to the system trust store and failed with
+// "x509: certificate signed by unknown authority".
+func TestTokenIdentityRootCAsWithOverride(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	testServer, caPEM, err := setupTLSServer(map[string]any{
+		"sub":  "subvalue",
+		"name": "namevalue",
+	}, true)
+	require.NoError(t, err)
+	defer testServer.Close()
+
+	conn, err := newConnector(Config{
+		Issuer:  testServer.URL,
+		Scopes:  []string{"openid", "groups"},
+		RootCAs: []string{caPEM},
+		// Setting an override forces provider construction through the override
+		// branch of getProvider. The JWKS URL matches discovery, so behaviour
+		// is otherwise identical to the no-override case.
+		ProviderDiscoveryOverrides: ProviderDiscoveryOverrides{
+			JWKSURL: testServer.URL + "/keys",
+		},
+	})
+	require.NoError(t, err)
+
+	res, err := testServer.Client().Get(testServer.URL + "/token")
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	var tokenResponse map[string]any
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&tokenResponse))
+
+	origToken := tokenResponse["id_token"].(string)
+	identity, err := conn.TokenIdentity(ctx, "urn:ietf:params:oauth:token-type:id_token", origToken)
+	require.NoError(t, err)
+
+	expectEquals(t, identity.UserID, "subvalue")
+	expectEquals(t, identity.Username, "namevalue")
+}
+
 func TestPromptType(t *testing.T) {
 	pointer := func(s string) *string {
 		return &s
@@ -738,7 +793,17 @@ func TestProviderOverride(t *testing.T) {
 	})
 }
 
-func setupServer(tok map[string]interface{}, idTokenDesired bool) (*httptest.Server, error) {
+// issuerURL derives the issuer base URL from the request, honoring TLS so the
+// same handler set can back both plain-HTTP and HTTPS test servers.
+func issuerURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return fmt.Sprintf("%s://%s", scheme, r.Host)
+}
+
+func oidcTestMux(tok map[string]interface{}, idTokenDesired bool) (*http.ServeMux, error) {
 	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate rsa key: %v", err)
@@ -765,7 +830,7 @@ func setupServer(tok map[string]interface{}, idTokenDesired bool) (*httptest.Ser
 	})
 
 	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
-		url := fmt.Sprintf("http://%s", r.Host)
+		url := issuerURL(r)
 		tok["iss"] = url
 		tok["exp"] = time.Now().Add(time.Hour).Unix()
 		tok["aud"] = "clientID"
@@ -795,7 +860,7 @@ func setupServer(tok map[string]interface{}, idTokenDesired bool) (*httptest.Ser
 	})
 
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
-		url := fmt.Sprintf("http://%s", r.Host)
+		url := issuerURL(r)
 
 		json.NewEncoder(w).Encode(&map[string]string{
 			"issuer":                 url,
@@ -806,7 +871,30 @@ func setupServer(tok map[string]interface{}, idTokenDesired bool) (*httptest.Ser
 		})
 	})
 
+	return mux, nil
+}
+
+func setupServer(tok map[string]interface{}, idTokenDesired bool) (*httptest.Server, error) {
+	mux, err := oidcTestMux(tok, idTokenDesired)
+	if err != nil {
+		return nil, err
+	}
 	return httptest.NewServer(mux), nil
+}
+
+// setupTLSServer starts an HTTPS OIDC test server and returns the server along
+// with its self-signed CA in PEM form, suitable for the connector's RootCAs.
+func setupTLSServer(tok map[string]interface{}, idTokenDesired bool) (*httptest.Server, string, error) {
+	mux, err := oidcTestMux(tok, idTokenDesired)
+	if err != nil {
+		return nil, "", err
+	}
+	srv := httptest.NewTLSServer(mux)
+	caPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: srv.Certificate().Raw,
+	})
+	return srv, string(caPEM), nil
 }
 
 func newToken(key *jose.JSONWebKey, claims map[string]interface{}) (string, error) {


### PR DESCRIPTION
## Problem

When an OIDC connector sets `providerDiscoveryOverrides`, `getProvider` rebuilt the provider with a bare `context.Background()`, dropping the `rootCAs`-aware `oauth2.HTTPClient` carried in the incoming context. The RFC 8693 token-exchange path verifies the JWKS using the provider's **build-time** HTTP client (the go-oidc `RemoteKeySet` stores the context given at provider construction), so the exchange fell back to the system trust store and failed with:

```
x509: certificate signed by unknown authority
```

This only affected issuers served behind a custom CA (e.g. a JWKS reachable over a SPIFFE/tunnelled endpoint). Login and refresh were unaffected because they use the verify-time client.

## Solution

Pass the incoming `ctx` to `config.NewProvider(ctx)` in the override branch so the rebuilt provider keeps the `rootCAs` client. No connector configuration change is required.

## Test

Adds `TestTokenIdentityRootCAsWithOverride`: an `httptest.NewTLSServer` serves the discovery document, JWKS and token endpoints; the connector is configured with the server's self-signed CA as `RootCAs` plus a `providerDiscoveryOverrides` entry (to exercise the override branch), and a `TokenIdentity` id_token exchange must succeed. On unpatched code this fails with the `x509: unknown authority` error above; with the fix it verifies. The existing tests used plain-HTTP `httptest.NewServer`, which could not catch a TLS/`rootCAs` regression.

Made with [Cursor](https://cursor.com)