### PR TITLE
ci: fix expired SAML test cert and yanked trivy-action dependency

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -205,7 +205,7 @@ jobs:
           restore-keys: trivy-cache-
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # 0.30.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           input: image
           format: sarif

--- a/connector/saml/saml_test.go
+++ b/connector/saml/saml_test.go
@@ -549,6 +549,11 @@ func runVerify(t *testing.T, ca string, resp string, shouldSucceed bool) {
 	s := certStore{[]*x509.Certificate{cert}}
 
 	validator := dsig.NewDefaultValidationContext(s)
+	// The testdata responses are captured historical SAML messages signed by
+	// certs with fixed lifetimes. Pin the validation clock to the signing
+	// cert's own validity window so signature verification stays reproducible
+	// as the fixtures age out (otherwise: "Cert is not valid at this time").
+	validator.Clock = dsig.NewFakeClockAt(cert.NotBefore)
 
 	data, err := os.ReadFile(resp)
 	if err != nil {


### PR DESCRIPTION
## What

Fixes two **unrelated, pre-existing** CI failures that are red on `main` and block every open PR (surfaced while reviewing #76):

1. **`Test` job** — `connector/saml` `TestVerify*` fail with `Cert is not valid at this time`.
2. **`Artifacts / Container images`** (alpine + distroless) — `Unable to resolve action aquasecurity/setup-trivy@v0.2.2`.

## Why / root cause

**SAML test cert expiry (time-bomb, not a regression):** the `testdata` files are captured *historical* SAML responses signed by certs with fixed lifetimes. `oam-ca.pem` expired on **2026-06-28**, so `goxmldsig`'s cert-validity check (`now.After(NotAfter)`) now rejects a signature that is otherwise perfectly valid. `okta-ca.pem` (Dec 2026) and `idp-cert.pem` (Jan 2027) are next.

Fix: pin the `goxmldsig` validation clock to the signing cert's own `NotBefore` in `runVerify` — the standard `dsig.NewFakeClockAt(...)` pattern goxmldsig uses in its own tests. This makes signature verification reproducible regardless of wall-clock, and auto-covers all three certs (and future ones) since it keys off each loaded cert. Test-only change.

**Trivy action:** `trivy-action@0.30.0` internally referenced `aquasecurity/setup-trivy@v0.2.2`, a tag upstream **yanked**, so the composite action fails to resolve. Bump to `v0.36.0` (SHA-pinned), which pins `setup-trivy@v0.2.6`. CI-only change.

## Scope

No runtime/production code touched — only a test helper and a CI workflow action pin.

## Test plan

- [x] `go test -race ./connector/saml/` — passes (previously failed on `TestVerifyUnsignedMessageAndSignedAssertionWithRootXmlNs`)
- [ ] Container-image jobs resolve `setup-trivy` and run (verified in CI on this PR)

## Follow-up

Unblocks #76 (GitHub connector refresh tokens) once that branch is rebased on `main`.
